### PR TITLE
Regex refactor, empty repo ignore, readme reset

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"golang.org/x/oauth2"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -17,12 +16,14 @@ import (
 	"syscall"
 	"time"
 
+	"golang.org/x/oauth2"
+
 	"github.com/schollz/progressbar/v3"
 	"github.com/shurcooL/githubv4"
 )
 
 const (
-	CVERegex = "(?i)cve[-–][0-9]{4}[-–][0-9]{4,}"
+	CVERegex = "(?i)cve[-–_][0-9]{4}[-–_][0-9]{4,}"
 )
 
 var ReadmeQuery struct {


### PR DESCRIPTION
Fixes #20 

- CVE regex refactored
- Empty repos are now ignored
- Readme is reset before every query so the next repo won't use it for regex matches (in case it doesn't have it's own readme)

Now searches for CVE references in repo name, description and readme content.